### PR TITLE
use current runtime in tokio executor

### DIFF
--- a/tokio-executor-trait/Cargo.toml
+++ b/tokio-executor-trait/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.56.0"
 async-trait = "^0.1.42"
 
 [dependencies.tokio]
-version = "^1.0"
+version = "^1.4"
 default-features = false
 features = ["rt-multi-thread"]
 

--- a/tokio-executor-trait/src/lib.rs
+++ b/tokio-executor-trait/src/lib.rs
@@ -28,10 +28,7 @@ impl FullExecutor for Tokio {}
 
 impl Executor for Tokio {
     fn block_on(&self, f: Pin<Box<dyn Future<Output = ()>>>) {
-        // FIXME: use the current runtime once Handle::block_on gets available
-        tokio::runtime::Runtime::new()
-            .expect("failed to create runtime")
-            .block_on(f);
+        tokio::runtime::Handle::current().block_on(f);
     }
 
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Box<dyn Task> {


### PR DESCRIPTION
This also bumps the tokio dependency to at least v1.4 (where `Handle::block_on` first appears).